### PR TITLE
Update Predator_ioc.csv

### DIFF
--- a/Cytrox/Predator_ioc.csv
+++ b/Cytrox/Predator_ioc.csv
@@ -1,5 +1,6 @@
 2y4nothing[.]xyz
 5m5[.]io
+actumali[.]org
 addons[.]news
 adibjan[.]net
 adservices[.]gr[.]com
@@ -70,6 +71,7 @@ dragonair[.]xyz
 eagerfox[.]xyz
 ebill[.]cosmote[.]center
 efsyn[.]online
+eg-gov[.]org
 egyqaz[.]com
 engine[.]ninja
 enigmase[.]xyz
@@ -261,6 +263,7 @@ tly[.]link
 tovima[.]live
 trecv[.]xyz
 trecvf[.]xyz
+tribune-mg[.]xyz
 trkc[.]online
 tsrt[.]xyz
 tw[.]itter[.]me


### PR DESCRIPTION
Missed domains from ```Table 4: Some Cytrox Predator domains indicating country themes.``` https://citizenlab.ca/2021/12/pegasus-vs-predator-dissidents-doubly-infected-iphone-reveals-cytrox-mercenary-spyware/