### PR TITLE
fix: find will return -1 on failure

### DIFF
--- a/Blacktech/tscookie_data_decode.py
+++ b/Blacktech/tscookie_data_decode.py
@@ -105,7 +105,7 @@ def main():
     dec_data = decode_data(data, args.file + ".decode")
 
     dll_index = dec_data.find(MZ_HEADER)
-    if dll_index:
+    if dll_index != -1:
         dll_data = dec_data[dll_index:]
         dll = pefile.PE(data=dll_data)
         print("[*] Found main DLL : 0x{0:X}".format(dll_index))


### PR DESCRIPTION
find will return `-1` on failure not `0` or bool

```python
if -1:
    print("passwd")
```

This code snippet will print 1, so the `if` check to find header is incorrect. 